### PR TITLE
feat(inputSelect): support html

### DIFF
--- a/@querycap-ui/containers/package.json
+++ b/@querycap-ui/containers/package.json
@@ -5,11 +5,8 @@
   "peerDependencies": {
     "@babel/runtime-corejs3": "*",
     "@querycap-ui/core": "*",
-    "@querycap/reactutils": "*",
-    "@reactorx/core": "*",
     "lodash": "4.x",
-    "react": "17.x",
-    "rxjs": "*"
+    "react": "17.x"
   },
   "publishConfig": {
     "access": "public"

--- a/@querycap-ui/form-controls/InputSelect.tsx
+++ b/@querycap-ui/form-controls/InputSelect.tsx
@@ -135,7 +135,7 @@ export const InputSelect = (props: InputSelectProps) => {
           css={select().with(cover()).opacity(0).cursor("pointer")}
           readOnly
         />
-        <span>{value && display(value)}</span>&nbsp;
+        <span dangerouslySetInnerHTML={{ __html: `<span>${display(value)}</span>` }}></span>&nbsp;
       </div>
       <InputIcon pullRight>
         {allowClear && value && !valuesRef.current.disabled ? (
@@ -153,8 +153,11 @@ export const InputSelect = (props: InputSelectProps) => {
           <SelectMenuPopover fullWidth triggerRef={inputElmRef} onRequestClose={() => closePopover()}>
             <MenuOptGroup>
               {map(values, (value) => (
-                <div data-opt={value} key={value}>
-                  {display(value)}
+                <div
+                  data-opt={value}
+                  key={value}
+                  dangerouslySetInnerHTML={{ __html: `<span>${display(value)}</span>` }}>
+                  {/* {display(value)} */}
                 </div>
               ))}
             </MenuOptGroup>

--- a/@querycap-ui/form-controls/__examples__/InputSelect.tsx
+++ b/@querycap-ui/form-controls/__examples__/InputSelect.tsx
@@ -11,7 +11,11 @@ export const InputSelects = () => {
   const [value, setValue] = useState(undefined);
   const [count, setCount] = useState("");
 
-  const enums = ["Apple", "Orange", "Banana"];
+  const enums = [
+    "<span style='color:red'>Apple<span style='font-size:14px;color:green'>苹果</span></span>",
+    "Orange",
+    "Banana",
+  ];
 
   const moreEnums = times(50);
 


### PR DESCRIPTION
inputSelect support html 
```javascript
enums:[  
    "<span style='color:red'>Apple<span style='font-size:14px;color:green'>苹果</span></span>",
    "Orange",
    "Banana",
]
```
result:
![image](https://user-images.githubusercontent.com/31394482/119324458-6f279e00-bcb2-11eb-8a1f-f364a4e32df4.png)
